### PR TITLE
Missing an "e" off Mike Henke in the readme author list.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -146,7 +146,7 @@ Authors:
 Aaron Greenlee - http://aarongreenlee.com
 Sean Coyne - http://www.n42designs.com
 Dan Skaggs - http://TNTechnoHermit.com
-Mike Henk - http://www.henke.ws
+Mike Henke - http://www.henke.ws
 James Brown - http://coldfusioning.com
 Dave Shuck - http://daveshuck.com
 Greg Moser - http://www.gregmoser.com


### PR DESCRIPTION
Just a tiny correction, spotted that Mike's surname was missing the last "e".
