### PR TITLE
Bleeding - Capture optional CF scopes

### DIFF
--- a/HothTracker.cfc
+++ b/HothTracker.cfc
@@ -74,6 +74,27 @@ accessors=false
 				,url		= CGI.HTTP_HOST & CGI.path_info
 				,client		= CGI.HTTP_USER_AGENT
 			};
+			
+			// check if configured to track additional ColdFusion scopes
+			local.scopes = UCase(variables.Config.getCaptureScopes());
+			
+			if (local.scopes!=""){
+				if (ListFind(local.scopes, "FORM") && !IsNull(FORM)) {
+					local.e.scopes.FORM = FORM;
+				}
+				if (ListFind(local.scopes, "URL") && !IsNull(URL)) {
+					local.e.scopes.URL = URL;
+				}
+				if (ListFind(local.scopes, "COOKIE") && !IsNull(COOKIE)) {
+					local.e.scopes.COOKIE = COOKIE;
+				}
+				if (ListFind(local.scopes, "CGI") && !IsNull(CGI)) {
+					local.e.scopes.CGI = CGI;
+				}
+				if (ListFind(local.scopes, "SESSION") && !IsNull(SESSION)) {
+					local.e.scopes.SESSION = SESSION;
+				}
+			}
 
 			// Generate JSON for hashing
 			local.json = {};

--- a/config/HothConfig.cfc
+++ b/config/HothConfig.cfc
@@ -74,6 +74,12 @@ component
 	/** Would you like HTML emails which contain the exception? */
 	property name='EmailExceptionsAsHTML'	default='false';
 	
+	/** List additional ColdFusion scopes you want to record to help debug / replicate issues
+		Accepts a comma delimited list of types. It's recommended that you do do record scopes 
+		that contain objects, but it will work!
+		Supported types are: FORM,URL,COOKIE,CGI,SESSION */
+	property name='CaptureScopes'			default='';
+	
 	// -------------------------------------------------------------------------
 	// HOTH REPORT SETTINGS (required)
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Added ability to track additional ColdFusion scopes such as Form, Cookie etc. By default these scopes are not recorded. User will need to set the scopes they want to capture in the Config using the capturescopes configuration setting.
