### PR TITLE
Bleeding

### DIFF
--- a/HothTracker.cfc
+++ b/HothTracker.cfc
@@ -76,22 +76,22 @@ accessors=false
 			};
 			
 			// check if configured to track additional ColdFusion scopes
+			// note: IsNull(FORM) on ACF9.0.1 always returns true which is why I'm using IsDefined
 			local.scopes = UCase(variables.Config.getCaptureScopes());
-			
 			if (local.scopes!=""){
-				if (ListFind(local.scopes, "FORM") && !IsNull(FORM)) {
+				if (ListFind(local.scopes,"FORM") && isDefined("FORM")) {
 					local.e.scopes.FORM = FORM;
 				}
-				if (ListFind(local.scopes, "URL") && !IsNull(URL)) {
+				if (ListFind(local.scopes,"URL") && isDefined("URL")) {
 					local.e.scopes.URL = URL;
 				}
-				if (ListFind(local.scopes, "COOKIE") && !IsNull(COOKIE)) {
+				if (ListFind(local.scopes,"COOKIE") && isDefined("COOKIE")) {
 					local.e.scopes.COOKIE = COOKIE;
 				}
-				if (ListFind(local.scopes, "CGI") && !IsNull(CGI)) {
+				if (ListFind(local.scopes,"CGI") && isDefined("CGI")) {
 					local.e.scopes.CGI = CGI;
 				}
-				if (ListFind(local.scopes, "SESSION") && !IsNull(SESSION)) {
+				if (ListFind(local.scopes,"SESSION") && isDefined("SESSION")) {
 					local.e.scopes.SESSION = SESSION;
 				}
 			}
@@ -147,6 +147,13 @@ accessors=false
 						,"Address: " & local.url
 						,variables.Config.getEmailFooter()
 					];
+					
+					if ( StructKeyExists( local.e, "Context" ) ) {
+						ArrayAppend( local.emailBody, "Exception Context:" );
+						for ( local.thisContext in local.e.Context ) {
+							ArrayAppend( local.emailBody, local.thisContext.Template & " :: " & local.thisContext.Line );									
+						}
+					}
 
 					if ( variables.Config.getUseDefaultMailServer() ) {
 						local.Mail = new Mail(	 subject='Hoth Exception (' & variables.Config.getApplicationName() & ') ' & local.index.key
@@ -181,7 +188,7 @@ accessors=false
 						local.Mail.setType( "html" );
 						savecontent variable="local.emailBody" {
 							writeOutput( arrayToList( local.emailBody, "<br />" ) );
-							writeOutput( "<br />Exception Details:<br />");
+							writeOutput( "<br /><br />Exception Details:<br />");
 							writeDump( local.e );
 						}
 						local.Mail.setBody( local.emailBody );


### PR DESCRIPTION
1) Show template and line number of exception in emails. For example: 

Exception Context:
C:\webserver\htdocs\mysite\views\home.cfm :: 7
C:\webserver\htdocs\mysite\frameworks\coldbox_3_5\system\plugins\Renderer.cfc :: 329
C:\webserver\htdocs\mysite\frameworks\coldbox_3_5\system\plugins\Renderer.cfc :: 174
C:\webserver\htdocs\mysite\layouts\Layout.Main.cfm :: 86
C:\webserver\htdocs\mysite\frameworks\coldbox_3_5\system\plugins\Renderer.cfc :: 329
C:\webserver\htdocs\mysite\frameworks\coldbox_3_5\system\plugins\Renderer.cfc :: 460
C:\webserver\htdocs\mysite\frameworks\coldbox_3_5\system\Coldbox.cfc :: 256
C:\webserver\htdocs\joshuasharveststore\Application.cfc :: 141

2) Fixed bug with additional scopes detection in ACF9.0.1
