### PR TITLE
Lucee compat fix

### DIFF
--- a/HothTracker.cfc
+++ b/HothTracker.cfc
@@ -247,7 +247,7 @@ accessors=false
 	private void function verifyDirectoryStructure() {
 		// Verify our index diectory exists
 
-		/** Ensure our directory structure is as expected. */
+		/* Ensure our directory structure is as expected. */
 		lock name=VARIABLES._NAME timeout=variables.Config.getTimeToLock() type="exclusive" {
 			if (!directoryExists(variables.paths.Exceptions)) {
 				directoryCreate(variables.paths.Exceptions);


### PR DESCRIPTION
Lucee seem to get confused by the `/**` (guessing it's trying to parse as a function meta data). Changing to `/*` fixes it!